### PR TITLE
Add runtime transform to babel compilation for dist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,5 +5,5 @@
         }],
         "@babel/preset-react"
     ],
-    "plugins": ["@babel/plugin-proposal-class-properties"]
+    "plugins": ["@babel/plugin-proposal-class-properties", "@babel/transform-runtime"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -761,9 +761,9 @@
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
-      "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz",
+      "integrity": "sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
@@ -2147,6 +2147,18 @@
             "@babel/helper-replace-supers": "^7.1.0",
             "@babel/helper-split-export-declaration": "^7.0.0",
             "globals": "^11.1.0"
+          }
+        },
+        "@babel/plugin-transform-runtime": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.2.0.tgz",
+          "integrity": "sha512-jIgkljDdq4RYDnJyQsiWbdvGeei/0MOTtSHKO/rfbd/mXBxNpdlulMx49L0HQ4pug1fXannxoqCI+fYSle9eSw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.0.0",
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "resolve": "^1.8.1",
+            "semver": "^5.5.1"
           }
         },
         "debug": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@babel/cli": "^7.2.3",
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.3.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@types/jest": "^24.0.6",


### PR DESCRIPTION
Previously dist assumed that ‘regeneratorRuntime’ existed in the node_modules map or was resolved by the browser.
This is not always the case (e.g. using react-spotify-api in Framer X)