### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "react-scripts": "^2.1.5",
     "react-styleguidist": "^8.0.6"
   },
+	"dependencies": {
+		"@babel/runtime": "^7.4.4"
+  },
   "peerDependencies": {
     "prop-types": "*",
     "react": ">=16.8.1",


### PR DESCRIPTION
I've realised that the inclusion of the `@babel/plugin-transform-runtime` wasn't actually enough, there needs to also be a dependency on `@babel/runtime` itself. I've added this as a dependency on for the library itself rather than a peerDep as I understand that it's supposed to be non-polluting.

I must have already had it installed from testing when I was proposing adding the plugin to .babelrc

See https://babeljs.io/docs/en/babel-plugin-transform-runtime#technical-details for information on why