### PR TITLE
Improve Api Error Handling in useApiRequest hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --no-watch",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "dist": "babel src/lib --out-dir dist --no-comments --ignore \"src/lib/**/*.test.js\" --config-file \"./.babelrc\"",
     "styleguide": "styleguidist server",

--- a/src/lib/ApiRequest/useApiRequest.js
+++ b/src/lib/ApiRequest/useApiRequest.js
@@ -19,7 +19,13 @@ function useApiRequest(url, options = {}) {
           }
         });
         const data = await res.json();
-        setData(data);
+        if (data.error) {
+          setError(data.error);
+        } else if (!res.ok) {
+          setError({ status: res.status });
+        } else {
+          setData(data);
+        }
         setLoading(false);
       } catch (e) {
         setLoading(false);

--- a/src/lib/ApiRequest/useApiRequest.test.js
+++ b/src/lib/ApiRequest/useApiRequest.test.js
@@ -45,8 +45,38 @@ describe('useApiRequest using a component to show hook state', () => {
     it('sets error state property when an error occurs', done => {
         let wrapper;
         act(() => {
-            // this is the wrong url, which should throw an error according to the mock in line 27
+            // this url will throw an error as configured in setupTests.js fetch mock
             wrapper = mount(<Wrapper url="" />);
+        });
+        process.nextTick(() => {
+            act(() => {
+                wrapper.update();
+            });
+            expect(wrapper.find('h1').text()).toEqual('error');
+            done();
+        });
+    });
+
+    it('sets error state property when api error data is received', done => {
+        let wrapper;
+        act(() => {
+            // this url will result in json error response as configured in setupTests.js fetch mock
+            wrapper = mount(<Wrapper url="api.error" />);
+        });
+        process.nextTick(() => {
+            act(() => {
+                wrapper.update();
+            });
+            expect(wrapper.find('h1').text()).toEqual('error');
+            done();
+        });
+    });
+
+    it('sets error state property when a not ok response is received', done => {
+        let wrapper;
+        act(() => {
+            // this url will result in a not ok response as configured in setupTests.js fetch mock
+            wrapper = mount(<Wrapper url="api.not.ok" />);
         });
         process.nextTick(() => {
             act(() => {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -21,7 +21,8 @@ global.beforeEach(() => {
             })
         } else if (url === 'api.not.ok') {
             return Promise.resolve({
-                ok: false
+                ok: false,
+                status: 401
             })
         }
         return Promise.resolve({

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -8,8 +8,24 @@ global.beforeEach(() => {
         // throw an error if the url is empty
         if (url === '') {
             return Promise.reject({ reason: 'wrong url' });
+        } else if (url === 'api.error') {
+            return Promise.resolve({
+                ok: false,
+                json: () =>
+                    Promise.resolve({
+                      error: {
+                          status: 401,
+                          message: 'Invalid access token'
+                      }
+                    })
+            })
+        } else if (url === 'api.not.ok') {
+            return Promise.resolve({
+                ok: false
+            })
         }
         return Promise.resolve({
+            ok: true,
             json: () =>
                 Promise.resolve({
                     url


### PR DESCRIPTION
Idea for solving #22 

## Intent
Allow developers to handle errors returned by the api, based on the message or status code returned (e.g. unauthorized, rate limiting etc.)

I've tried to keep the error handling as simple as possible, keen to hear your thoughts.
